### PR TITLE
Enable jest-dom in tests

### DIFF
--- a/src/App.test.jsx
+++ b/src/App.test.jsx
@@ -5,5 +5,5 @@ import App from './App';
 test('renders learn react link', () => {
   render(<App />);
   const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeDefined();
+  expect(linkElement).toBeInTheDocument();
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,5 +7,6 @@ export default defineConfig({
   test: {
     globals: true,
     environment: 'jsdom',
+    setupFiles: './src/setupTests.js',
   },
 })


### PR DESCRIPTION
## Summary
- use `toBeInTheDocument` in `App.test.jsx`
- configure Vitest to load `src/setupTests.js` so custom matchers are registered

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6843ed5e86bc8328b5cd879d7aec85e7